### PR TITLE
test: final LLM review probe on account

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,5 @@ node antigravity/antigravity-pipeline.mjs --from-csv --accounts qws94201@gmail.c
 ## 라이선스
 
 비공개 — 내부 사용 전용.
+
+<!-- LLM final probe 1777812018 -->


### PR DESCRIPTION
Final probe after all 3 stages of fixes:
1. GITHUB__USER_TOKEN (dynaconf nested key for github.user_token)
2. OPENAI.KEY (litellm api_key path - was OPENAI_KEY single-underscore)
3. CONFIG.CUSTOM_MODEL_MAX_TOKENS=128000 (kimi/claude not in MAX_TOKENS table)

Expected: github-actions[bot] posts a Korean LLM review comment within ~90s.