### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -41,7 +41,6 @@ jobs:
           rm /tmp/actionlint.tar.gz
           ./actionlint --version
         shell: bash
-        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
 
       - name: Run actionlint

--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -49,7 +49,6 @@ permissions:
 concurrency:
   group: ci-failure-issues-${{ github.event.workflow_run.head_sha || inputs.head_sha || github.run_id }}
   cancel-in-progress: false
-  group: ci-failure-issues-${{ github.event.workflow_run.head_sha || inputs.head_sha }}
   cancel-in-progress: false
 
 jobs:
@@ -115,7 +114,6 @@ jobs:
             echo "short_sha=${HEAD_SHA:0:8}"
             echo "pr_number=$PR_NUMBER"
           } >> "$GITHUB_OUTPUT"
-        id: ev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- GitHub Actions 워크플로우 YAML 구문 오류 수정

- `actionlint.yml` 중복 설치 스크립트 제거

- `ci-failure-issues.yml` 중복 `concurrency` 키 정리

- `ci-failure-issues.yml` 불필요한 `id` 제거


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actionlint.yml</strong><dd><code>actionlint 워크플로우 중복 설치 스크립트 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/actionlint.yml

<ul><li>수동 다운로드 단계 하위에 잘못 추가된 중복 <code>run</code> 명령(<code>download-actionlint.bash</code> curl 호출) 제거<br> <li> 워크플로우 YAML 문법 오류 및 중복 실행 방지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/36/files#diff-7ead7509c09411da47590f81c50314ace562cf4a25d49ecf60e926cb47589f9c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-failure-issues.yml</strong><dd><code>ci-failure-issues 워크플로우 중복 키 및 ID 정리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-failure-issues.yml

<ul><li><code>concurrency</code> 섹션 내 중복된 <code>group</code> 키 제거<br> <li> <code>steps</code> 영역에서 잘못 배치되거나 불필요한 <code>id: ev</code> 제거</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/36/files#diff-7e6f6ffd47cfb5fa52b303eadd7d50550a4f855045369b1c0501e751d40b32d6">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

