### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: self-hosted
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -44,7 +44,7 @@ jobs:
   scan:
     # Gitleaks does not need self-hosted resources; ubuntu-latest avoids
     # gitleaks-action@v2 install failures on self-hosted runners.
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -44,7 +44,7 @@ jobs:
   scan:
     # Gitleaks does not need self-hosted resources; ubuntu-latest avoids
     # gitleaks-action@v2 install failures on self-hosted runners.
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -59,8 +59,8 @@ jobs:
       - name: Install gitleaks
         run: |
           wget -qO /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
-          tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
-          chmod +x /usr/local/bin/gitleaks
+          sudo tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+          sudo chmod +x /usr/local/bin/gitleaks
 
       - name: Run gitleaks detect
         run: |

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   enable-auto-merge:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     # Trigger on either:
     #   1. an APPROVED review on a non-draft, non-bot PR

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   enable-auto-merge:
-    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: self-hosted
     timeout-minutes: 5
     # Trigger on either:
     #   1. an APPROVED review on a non-draft, non-bot PR

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,11 +10,6 @@ permissions:
 
 jobs:
   pr-checks:
-    # Run for every PR including dependabot[bot]. The required status
-    # contexts on branch protection (Check PR Title, Check Branch Name)
-    # apply to dependabot too; Dependabot satisfies them automatically
-    # because conventional commit titles and feat/fix/chore branch names
-    # are its default behavior.
     if: github.event_name == 'pull_request'
-    uses: jclee941/.github/.github/workflows/reusable-pr-checks.yml@master
+    uses: ./.github/workflows/reusable-pr-checks.yml
     secrets: inherit

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-size:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     name: Check PR Size
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   check-title:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     name: Check PR Title
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   check-branch:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     name: Check Branch Name
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   check-description:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     name: Check PR Description
     steps:
@@ -144,7 +144,7 @@ jobs:
 
   check-large-files:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     name: Check Large Files
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   check-sensitive-files:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     name: Check Sensitive Files
     steps:

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-size:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check PR Size
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   check-title:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check PR Title
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   check-branch:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check Branch Name
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   check-description:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check PR Description
     steps:
@@ -144,7 +144,7 @@ jobs:
 
   check-large-files:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check Large Files
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   check-sensitive-files:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Check Sensitive Files
     steps:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- Dependabot 및 자동 병합 러너를 `ubuntu-latest`로 변경

- `gitleaks` 바이너리 설치에 `sudo` 추가

- PR 검증 워크플로우를 로컬 경로로 변경


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["조건부 러너 설정"] -- "모든 워크플로우" --> B["ubuntu-latest 고정"]
  C["원격 재사용 워크플로우"] -- "참조 변경" --> D["로컬 경로 사용"]
  E["gitleaks 설치"] -- "권한 추가" --> F["sudo 명령어 사용"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml</strong><dd><code>Dependabot 자동 병합 러너를 ubuntu-latest로 고정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dependabot-auto-merge.yml

- 저장소 가시성 조건부 `runs-on` 구문 제거
- `ubuntu-latest` 러너로 일괄 실행하도록 변경


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/46/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-auto-merge.yml</strong><dd><code>PR 자동 병합 러너를 ubuntu-latest로 고정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-auto-merge.yml

- 조건부 `runs-on` 구문 제거
- `self-hosted` 없이 `ubuntu-latest`로 실행


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/46/files#diff-61c0d56ab06ca0109392dffccd6cf28b542b40fe66cdc5db85f8b6da53e9395d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr-checks.yml</strong><dd><code>PR 체크 워크플로우를 로컬 재사용 경로로 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-checks.yml

<ul><li>외부 <code>jclee941/.github</code> 저장소 참조를 <code>./.github/workflows/reusable-pr-checks.yml</code> <br>로컬 경로로 변경<br> <li> <code>jobs.pr-checks</code> 관련 불필요한 주석 블록 제거</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/46/files#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcb">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitleaks.yml</strong><dd><code>gitleaks 설치 시 sudo 권한 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gitleaks.yml

<ul><li><code>/usr/local/bin</code>에 압축 해제하는 <code>tar</code> 명령에 <code>sudo</code> 추가<br> <li> <code>chmod</code> 명령에도 <code>sudo</code> 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/46/files#diff-2aa7a05eafb406b4c582ed3bd35f2ef3a6fadeaad31372f62a79bd7610e1e453">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

