### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -39,12 +39,42 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          APPROVER_LOGIN: github-actions[bot]
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
         run: |
-          gh pr review --approve "$PR_URL" \
-            --body "Auto-approved by dependabot-auto-merge ($DEP_NAMES, $UPDATE_TYPE)" \
-          || echo "::warning::approve failed for $PR_URL (already approved or insufficient permissions); continuing"
+          set -euo pipefail
+
+          approval_id="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$APPROVER_LOGIN\" and .state == \"APPROVED\") | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$approval_id" ]]; then
+            echo "::notice::PR $PR_URL is already approved by $APPROVER_LOGIN (review id: $approval_id); skipping approval"
+            exit 0
+          fi
+
+          if gh pr review --approve "$PR_URL" \
+            --body "Auto-approved by dependabot-auto-merge ($DEP_NAMES, $UPDATE_TYPE)"; then
+            exit 0
+          fi
+
+          status=$?
+          approval_id="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$APPROVER_LOGIN\" and .state == \"APPROVED\") | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$approval_id" ]]; then
+            echo "::warning::approval command failed, but PR $PR_URL is now approved by $APPROVER_LOGIN (review id: $approval_id); treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to approve $PR_URL"
+          exit "$status"
 
       - name: Enable auto-merge for safe updates
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.package-ecosystem == 'github_actions' }}
@@ -52,28 +82,117 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr merge --auto --squash "$PR_URL" \
-          || echo "::warning::auto-merge enable failed for $PR_URL (allow_auto_merge disabled or branch protection missing); continuing"
+          set -euo pipefail
+
+          auto_merge_enabled="$(gh pr view "$PR_URL" \
+            --json autoMergeRequest \
+            --jq '.autoMergeRequest != null')"
+
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            echo "::notice::auto-merge is already enabled for $PR_URL; skipping"
+            exit 0
+          fi
+
+          if gh pr merge --auto --squash "$PR_URL"; then
+            exit 0
+          fi
+
+          status=$?
+          auto_merge_enabled="$(gh pr view "$PR_URL" \
+            --json autoMergeRequest \
+            --jq '.autoMergeRequest != null')"
+
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            echo "::warning::auto-merge command failed, but auto-merge is now enabled for $PR_URL; treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to enable auto-merge for $PR_URL"
+          exit "$status"
 
       - name: Flag major updates for manual review
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' && steps.meta.outputs.package-ecosystem != 'github_actions' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_AUTHOR: github-actions[bot]
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
         run: |
-          gh pr comment "$PR_URL" \
-            --body "Major version bump for $DEP_NAMES - manual review required." \
-          || echo "::warning::failed to post manual-review comment for $PR_URL; continuing"
+          set -euo pipefail
+
+          marker="<!-- dependabot-auto-merge:manual-review:major -->"
+          body="$marker"$'\n'"Major version bump for $DEP_NAMES - manual review required."
+
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::notice::major-update manual-review comment already exists on $PR_URL (comment id: $comment_id); skipping"
+            exit 0
+          fi
+
+          if gh pr comment "$PR_URL" --body "$body"; then
+            exit 0
+          fi
+
+          status=$?
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::warning::comment command failed, but major-update comment now exists on $PR_URL (comment id: $comment_id); treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to post major-update manual-review comment for $PR_URL"
+          exit "$status"
 
       - name: Flag unknown update type for manual review
         if: ${{ steps.meta.outputs.update-type == '' || steps.meta.outputs.update-type == 'null' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_AUTHOR: github-actions[bot]
           DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
           ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
         run: |
-          gh pr comment "$PR_URL" \
-            --body "Dependabot did not report a SemVer update-type for $DEP_NAMES (ecosystem=$ECOSYSTEM). Manual review required." \
-          || echo "::warning::failed to post unknown-update-type comment for $PR_URL; continuing"
+          set -euo pipefail
+
+          marker="<!-- dependabot-auto-merge:manual-review:unknown-update-type -->"
+          body="$marker"$'\n'"Dependabot did not report a SemVer update-type for $DEP_NAMES (ecosystem=$ECOSYSTEM). Manual review required."
+
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::notice::unknown-update-type manual-review comment already exists on $PR_URL (comment id: $comment_id); skipping"
+            exit 0
+          fi
+
+          if gh pr comment "$PR_URL" --body "$body"; then
+            exit 0
+          fi
+
+          status=$?
+          comment_id="$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --paginate \
+            --jq ".[] | select(.user.login == \"$COMMENT_AUTHOR\" and (.body | contains(\"$marker\"))) | .id" \
+            | tail -n 1)"
+
+          if [[ -n "$comment_id" ]]; then
+            echo "::warning::comment command failed, but unknown-update-type comment now exists on $PR_URL (comment id: $comment_id); treating as idempotent success"
+            exit 0
+          fi
+
+          echo "::error::failed to post unknown-update-type manual-review comment for $PR_URL"
+          exit "$status"

--- a/.github/workflows/reusable-docs-sync.yml
+++ b/.github/workflows/reusable-docs-sync.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create issue for broken links
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const body = `## 🚨 문서 링크 깨짐 감지\n\n` +
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check README sync
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -142,7 +142,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check API documentation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({

--- a/.github/workflows/reusable-issue-management.yml
+++ b/.github/workflows/reusable-issue-management.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Auto-label new issues
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue;
@@ -89,7 +89,7 @@ jobs:
     if: github.event_name == 'issue_comment' || (github.event_name == 'issues' && contains(fromJson('["reopened", "edited"]'), github.event.action))
     steps:
       - name: Remove stale label on activity
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue || context.payload.comment?.issue;
@@ -112,7 +112,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Generate Issue Statistics
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: issues } = await github.rest.issues.listForRepo({

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -54,7 +54,7 @@ jobs:
     name: Check PR Title
     steps:
       - name: Conventional Commits validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -80,7 +80,7 @@ jobs:
     name: Check Branch Name
     steps:
       - name: Branch naming validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
@@ -106,7 +106,7 @@ jobs:
     name: Check PR Description
     steps:
       - name: Description validation
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const body = context.payload.pull_request.body || '';
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect large file changes
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -191,7 +191,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect sensitive file changes
-        uses: actions/github-script@v9
+        uses: actions/github-script@v7
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- Dependabot 워크플로우에 멱등성 및 경쟁 상태 처리 추가

- github-script 액션을 v9에서 v7으로 일괄 다운그레이드

- 워크플로우 오류 처리 강화 및 자동화 안정성 향상


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dependabot-auto-merge.yml"]
  B["승인 및 병합 멱등성 확보"]
  C["reusable workflows"]
  D["github-script v7 다운그레이드"]
  A -- "멱등성 로직 추가" --> B
  C -- "v9 → v7" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml</strong><dd><code>Dependabot auto-merge 멱등성 및 오류 처리 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/dependabot-auto-merge.yml

<ul><li><code>set -euo pipefail</code> 설정으로 엄격한 오류 처리 적용<br> <li> 승인, 자동 병합, 코멘트 작성 전 기존 상태 확인 로직 추가<br> <li> 명령 실패 후 대상 상태를 재확인하여 경쟁 상태 안전성 확보<br> <li> 각 단계에서 이미 처리된 경우 건너뛰는 멱등성 패턴 구현</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/54/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+130/-11</a></td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reusable-docs-sync.yml</strong><dd><code>github-script 액션 v7로 다운그레이드</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-docs-sync.yml

<ul><li><code>actions/github-script</code> 버전을 <code>v9</code>에서 <code>v7</code>로 다운그레이드<br> <li> 문서 링크 점검, README 동기화, API 문서 확인 단계에 적용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/54/files#diff-4a1f29f72a980db95bc8265ef1c75404098d95a138d2c59772083ec5259c4d2a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-issue-management.yml</strong><dd><code>github-script 액션 v7로 다운그레이드</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-issue-management.yml

<ul><li><code>actions/github-script</code> 버전을 <code>v9</code>에서 <code>v7</code>로 다운그레이드<br> <li> 이슈 자동 라벨링, stale 제거, 통계 생성 단계에 적용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/54/files#diff-321d5a584f7c9be882556476d570355f5243ec98cb2925e63566ada047783335">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-pr-checks.yml</strong><dd><code>github-script 액션 v7로 다운그레이드</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-pr-checks.yml

<ul><li><code>actions/github-script</code> 버전을 <code>v9</code>에서 <code>v7</code>로 다운그레이드<br> <li> PR 제목, 브랜치명, 설명, 대용량 파일, 민감 파일 검사 단계에 적용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/54/files#diff-c847d70b033c8a55778bee6b336f27519c76efbe8d9f7b8c67108ef006d42ee7">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

