### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,14 +18,18 @@ permissions:
   issues: write
 
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: pr-review-${{ github.event.pull_request.number }}-${{ matrix.model }}
+cancel-in-progress: true
 
 jobs:
   pr_review:
+    strategy:
+      matrix:
+        model: [kimi-k2.6, minimax-m2.7]
+      fail-fast: false
     if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
-    name: PR review via CLIProxyAPI
+    name: PR review via CLIProxyAPI (${{ matrix.model }})
     timeout-minutes: 30
 
     steps:
@@ -97,7 +101,7 @@ jobs:
           OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
           LITELLM_LOG: 'DEBUG'
           LITELLM_LOCAL_MODEL_COST_MAP: "True"
-          CONFIG.MODEL: kimi-k2.6
+          CONFIG.MODEL: ${{ matrix.model }}
           CONFIG.FALLBACK_MODELS: '["minimax-m2.7"]'
           CONFIG.RESPONSE_LANGUAGE: ko
           CONFIG.AI_TIMEOUT: "180"
@@ -124,6 +128,7 @@ jobs:
           # the workflow portable to any runner.
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_REVIEWER.EXTRA_INSTRUCTIONS: |
+            [Model: ${{ matrix.model }}]
             이 리뷰는 표준 코드 리뷰 모드입니다.
             다음 관점에서 체계적으로 점검하십시오.
 


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- PR 리뷰에 dual-model 매트릭스 전략 추가

- kimi-k2.6과 minimax-m2.7 병렬 실행 지원

- 동시성 그룹 키에 모델 정보 포함

- 리뷰 지시문에 모델 식별자 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["PR 이벤트"] --> Matrix["매트릭스 분기"]
  Matrix --> K["kimi-k2.6 리뷰"]
  Matrix --> M["minimax-m2.7 리뷰"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-review.yml</strong><dd><code>PR 리뷰 다중 AI 모델 매트릭스 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-review.yml

<ul><li><code>jobs.pr_review</code>에 <code>kimi-k2.6</code>과 <code>minimax-m2.7</code> 매트릭스 추가 및 <code>fail-fast: false</code> 설정<br> <li> 동시성 그룹과 <code>CONFIG.MODEL</code>을 <code>${{ matrix.model }}</code>로 매개변수화<br> <li> 리뷰어 추가 지시문에 <code>[Model: ${{ matrix.model }}]</code> 태그 삽입</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/56/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

