### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,110 @@
+name: Release Notes Generator
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to generate release notes for'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-notes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate Release Notes
+        id: notes
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep -v "$TAG" | head -n 1)
+          
+          if [ -z "$PREVIOUS_TAG" ]; then
+            RANGE="$TAG"
+          else
+            RANGE="$PREVIOUS_TAG..$TAG"
+          fi
+          
+          echo "## What's Changed in $TAG" > release_notes.md
+          echo "" >> release_notes.md
+          
+          # Categorize commits
+          FEATS=$(git log --pretty=format:"- %s (%h)" "$RANGE" --grep="^feat" 2>/dev/null || true)
+          FIXES=$(git log --pretty=format:"- %s (%h)" "$RANGE" --grep="^fix" 2>/dev/null || true)
+          DOCS=$(git log --pretty=format:"- %s (%h)" "$RANGE" --grep="^docs" 2>/dev/null || true)
+          REFACTORS=$(git log --pretty=format:"- %s (%h)" "$RANGE" --grep="^refactor" 2>/dev/null || true)
+          CHORES=$(git log --pretty=format:"- %s (%h)" "$RANGE" --grep="^chore" 2>/dev/null || true)
+          
+          if [ -n "$FEATS" ]; then
+            echo "### ✨ Features" >> release_notes.md
+            echo "$FEATS" >> release_notes.md
+            echo "" >> release_notes.md
+          fi
+          
+          if [ -n "$FIXES" ]; then
+            echo "### 🐛 Bug Fixes" >> release_notes.md
+            echo "$FIXES" >> release_notes.md
+            echo "" >> release_notes.md
+          fi
+          
+          if [ -n "$DOCS" ]; then
+            echo "### 📚 Documentation" >> release_notes.md
+            echo "$DOCS" >> release_notes.md
+            echo "" >> release_notes.md
+          fi
+          
+          if [ -n "$REFACTORS" ]; then
+            echo "### 🔧 Refactoring" >> release_notes.md
+            echo "$REFACTORS" >> release_notes.md
+            echo "" >> release_notes.md
+          fi
+          
+          if [ -n "$CHORES" ]; then
+            echo "### 🧹 Maintenance" >> release_notes.md
+            echo "$CHORES" >> release_notes.md
+            echo "" >> release_notes.md
+          fi
+          
+          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/$PREVIOUS_TAG...$TAG" >> release_notes.md
+          
+          cat release_notes.md
+          
+          # Set output for next step
+          BODY=$(cat release_notes.md)
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create or Update Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          BODY="${{ steps.notes.outputs.body }}"
+          
+          # Check if release exists
+          EXISTING=$(gh release view "$TAG" --repo "${{ github.repository }}" --json url 2>/dev/null || echo "")
+          
+          if [ -n "$EXISTING" ]; then
+            gh release edit "$TAG" --repo "${{ github.repository }}" --notes "$BODY"
+            echo "Updated release $TAG"
+          else
+            gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --notes "$BODY"
+            echo "Created release $TAG"
+          fi


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 버전 태그 푸시 시 릴리스 노트 자동 생성

- 커밋 타입별 변경사항 분류 및 정리

- GitHub 릴리스 자동 생성 및 업데이트 지원

- workflow_dispatch를 통한 수동 실행 기능 지원


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["v* 태그 푸시 또는 수동 실행"] --> checkout["Checkout 코드"]
  checkout --> categorize["커밋 타입별 분류<br/>(feat, fix, docs, refactor, chore)"]
  categorize --> generate["릴리스 노트 생성"]
  generate --> release["GitHub 릴리스 생성/업데이트"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-notes.yml</strong><dd><code>릴리스 노트 자동 생성 워크플로우 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-notes.yml

<ul><li><code>v*</code> 태그 푸시 또는 <code>workflow_dispatch</code> 입력으로 트리거되는 릴리스 노트 생성 워크플로우 신규 추가<br> <li> 이전 태그와의 커밋 범위에서 <code>feat</code>, <code>fix</code>, <code>docs</code>, <code>refactor</code>, <code>chore</code> 타입별 변경사항을 분류하여 마크다운 <br>형식으로 작성<br> <li> <code>gh release create</code> 또는 <code>gh release edit</code> 명령을 통해 GitHub 릴리스를 자동으로 생성하거나 기존 <br>릴리스를 업데이트<br> <li> <code>actions/checkout@v6</code>와 <code>GH_TOKEN</code> 환경변수를 사용하며, <code>timeout-minutes: 5</code> 및 <br>concurrency 설정으로 실행 제어</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/62/files#diff-42244398366244a59eb9bb95d4d4f8f8657297b9e8e5bf3a815f3e8cca374ce1">+110/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

