### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -26,5 +26,3 @@ jobs:
     timeout-minutes: 15
     uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
     secrets: inherit
-    uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
-    secrets: inherit

--- a/.github/workflows/readme-gen.yml
+++ b/.github/workflows/readme-gen.yml
@@ -1,0 +1,109 @@
+name: README Generator
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Weekly auto-generation (Sundays 00:00 UTC)
+  schedule:
+    - cron: '0 0 * * 0'
+  # Trigger when source/config files change on master
+  push:
+    branches: [master, main]
+    paths-ignore:
+      - 'README.md'
+      - '.github/workflows/readme-gen.yml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: readme-gen-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate_readme:
+    if: github.repository != 'jclee941/.github'  # skip source repo
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    name: Generate README.md via CLIProxyAPI
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Check out readme generator script
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          path: _bot-scripts
+          sparse-checkout: |
+            scripts/generate_readme.py
+          fetch-depth: 1
+
+      - name: Generate README.md
+        env:
+          CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
+          OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
+        run: |
+          set -e
+          python3 _bot-scripts/scripts/generate_readme.py --repo .
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to README.md"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "README.md changed"
+          fi
+
+      - name: Commit and push to branch
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -e
+          git config user.email "bot@jclee.me"
+          git config user.name "github-bot"
+          git checkout -b bot/auto-readme-update
+          git add README.md
+          git commit -m "docs: auto-update README.md [skip ci]"
+          gh auth setup-git
+          git push -u origin bot/auto-readme-update --force-with-lease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create or update PR
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -e
+          existing=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --title "docs: auto-update README.md" --body "Automated README.md update by jclee-bot."
+          else
+            gh pr create \
+              --title "docs: auto-update README.md" \
+              --body "Automated README.md update by jclee-bot." \
+              --base "${GITHUB_REF_NAME}" \
+              --head bot/auto-readme-update
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          set -e
+          pr_number=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
+          gh pr merge "$pr_number" --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- README 자동 생성 워크플로우 신규 추가

- docs-sync 워크플로우 중복 `uses` 선언 제거

- CLIProxyAPI 연동 및 자동 PR 머지 기능 포함


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["Push/Schedule/Manual"] --> readme_gen["readme-gen.yml"]
  readme_gen --> generate["Generate README.md"]
  generate --> pr["Create/Update PR"]
  pr --> merge["Auto-merge"]
  docs_sync["docs-sync.yml"] --> fix["Remove duplicate lines"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docs-sync.yml</strong><dd><code>docs-sync 워크플로우 중복 항목 정리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docs-sync.yml

- `jobs.docs-sync` 단계에서 중복되던 `uses` 및 `secrets: inherit` 선언 2줄 제거


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/63/files#diff-f4bfcbba69692fc3c503c6de06be0057b3d1cd35571b3d0e7f14ad12737f217d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>readme-gen.yml</strong><dd><code>README 자동 생성 워크플로우 신규 도입</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/readme-gen.yml

<ul><li>README.md 자동 생성 워크플로우 신규 추가<br> <li> 수동 실행, 주간 스케줄, 소스 파일 변경 시 자동 트리거 설정<br> <li> CLIProxyAPI를 활용한 README 생성 및 변경 시 자동 PR 생성/머지 구현</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/63/files#diff-f9347e8d7f39ffd679c6b9e3031a4e05bf239457bb5c4d31dc89130ad26cd462">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

