### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/10_pr-review.yml
+++ b/.github/workflows/10_pr-review.yml
@@ -21,14 +21,16 @@ jobs:
   pr_review:
     strategy:
       matrix:
-        model: [minimax-m2.7, gpt-5.5]
+        model: [MiniMax-M3]
+      # max-parallel 1: MiniMax direct API rate-limit guard (one in-flight call)
+      max-parallel: 1
       fail-fast: false
     concurrency:
       group: pr-review-${{ github.event.pull_request.number }}-${{ matrix.model }}
       cancel-in-progress: true
     if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
-    name: PR review via CLIProxyAPI (${{ matrix.model }})
+    name: PR review via MiniMax (${{ matrix.model }})
     timeout-minutes: 30
 
     steps:
@@ -70,32 +72,31 @@ jobs:
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install -e .
 
-      - name: Verify cli_proxy connectivity
+      - name: Verify MiniMax connectivity
         id: cli_proxy
         env:
-          CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
           set -eu
           set +e
-          if [ -z "$CLIPROXY_API_KEY" ]; then
-            echo "::warning::CLIPROXY_API_KEY secret is not set on this repo; skipping review."
+          if [ -z "$MINIMAX_API_KEY" ]; then
+            echo "::warning::MINIMAX_API_KEY secret is not set on this repo; skipping review."
             echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "reason=CLIPROXY_API_KEY secret not set" >> "$GITHUB_OUTPUT"
+            echo "reason=MINIMAX_API_KEY secret not set" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          HTTP_CODE=$(curl -sS -o /tmp/cli_proxy_test.json -w '%{http_code}' \
+          HTTP_CODE=$(curl -sS -o /tmp/minimax_test.json -w '%{http_code}' \
             --max-time 15 \
-            https://cliproxy.jclee.me/v1/models \
-            -H "Authorization: Bearer $CLIPROXY_API_KEY")
+            https://api.minimax.io/v1/models \
+            -H "Authorization: Bearer $MINIMAX_API_KEY")
           if [ "$HTTP_CODE" != "200" ]; then
-            echo "::warning::cli_proxy returned HTTP $HTTP_CODE; skipping review."
-            cat /tmp/cli_proxy_test.json || true
+            echo "::warning::MiniMax API returned HTTP $HTTP_CODE; skipping review."
+            cat /tmp/minimax_test.json || true
             echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "reason=cli_proxy HTTP $HTTP_CODE" >> "$GITHUB_OUTPUT"
+            echo "reason=MiniMax HTTP $HTTP_CODE" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          MODEL_COUNT=$(python3 -c "import json; print(len(json.load(open('/tmp/cli_proxy_test.json'))['data']))")
-          echo "cli_proxy OK - $MODEL_COUNT models available"
+          echo "MiniMax API OK (HTTP 200)"
           echo "ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Install GitHub CLI
@@ -116,22 +117,21 @@ jobs:
           # POSIX-valid dynaconf nested keys use double-underscore.
           # `OPENAI__KEY` → settings.openai.key, etc. See note below for the
           # GITHUB__USER_TOKEN case.
-          OPENAI__KEY: ${{ secrets.CLIPROXY_API_KEY }}
-          OPENAI__API_BASE: https://cliproxy.jclee.me/v1
-          OPENAI_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
-          OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
+          OPENAI__KEY: ${{ secrets.MINIMAX_API_KEY }}
+          OPENAI__API_BASE: https://api.minimax.io/v1
+          OPENAI_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          OPENAI_BASE_URL: https://api.minimax.io/v1
           LITELLM_LOG: ${{ vars.PR_REVIEW_DEBUG == '1' && 'DEBUG' || 'INFO' }}
           LITELLM_LOCAL_MODEL_COST_MAP: "True"
           PR_REVIEW_DEBUG: ${{ vars.PR_REVIEW_DEBUG || '0' }}
           CONFIG__MODEL: ${{ matrix.model }}
           # Canonical fallback chain (matches .pr_agent.toml + configuration.toml +
-          # all review workflows; enforced by 90_sanity.yml). If matrix.model also
-          # appears here, it may be retried once as part of the finite fallback
-          # list; this is harmless but not deduplicated (no loop).
-          CONFIG__FALLBACK_MODELS: '["minimax-m2.7", "gpt-5.5"]'
+          # all review workflows; enforced by 90_sanity.yml). Single-model direct
+          # MiniMax: fallback == primary == MiniMax-M3 (one retry, no loop).
+          CONFIG__FALLBACK_MODELS: '["MiniMax-M3"]'
           CONFIG__RESPONSE_LANGUAGE: ko
           CONFIG__AI_TIMEOUT: "180"
-          CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"
+          CONFIG__CUSTOM_MODEL_MAX_TOKENS: "1000000"
           # Quality knobs — produce richer review output even on small diffs.
           # See pr_agent/tools/pr_reviewer.py:85-94 for toggle->prompt mapping.
           PR_REVIEWER__REQUIRE_SCORE_REVIEW: "true"

--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -54,8 +54,8 @@ jobs:
 
       - name: Generate README.md
         env:
-          CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
-          OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          OPENAI_BASE_URL: https://api.minimax.io/v1
         run: |
           set -eu
           python3 _bot-scripts/scripts/generate_readme.py --repo .

--- a/.github/workflows/security/11_pr-review.yml
+++ b/.github/workflows/security/11_pr-review.yml
@@ -52,35 +52,34 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
-      - name: Verify cli_proxy connectivity
+      - name: Verify MiniMax connectivity
         env:
-          CLIPROXY_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
           set -e
-          HTTP_CODE=$(curl -sS -o /tmp/cli_proxy_test.json -w '%{http_code}' \
+          HTTP_CODE=$(curl -sS -o /tmp/minimax_test.json -w '%{http_code}' \
             --max-time 15 \
-            https://cliproxy.jclee.me/v1/models \
-            -H "Authorization: Bearer $CLIPROXY_API_KEY")
+            https://api.minimax.io/v1/models \
+            -H "Authorization: Bearer $MINIMAX_API_KEY")
           if [ "$HTTP_CODE" != "200" ]; then
-            echo "ERROR: cli_proxy returned HTTP $HTTP_CODE"
-            cat /tmp/cli_proxy_test.json
+            echo "ERROR: MiniMax API returned HTTP $HTTP_CODE"
+            cat /tmp/minimax_test.json
             exit 1
           fi
-          MODEL_COUNT=$(python3 -c "import json; print(len(json.load(open('/tmp/cli_proxy_test.json'))['data']))")
-          echo "cli_proxy OK — $MODEL_COUNT models available"
+          echo "MiniMax API OK (HTTP 200)"
 
       - name: Run deep security review
         env:
-          OPENAI__KEY: ${{ secrets.CLIPROXY_API_KEY }}
-          OPENAI__API_BASE: https://cliproxy.jclee.me/v1
-          OPENAI_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
-          OPENAI_BASE_URL: https://cliproxy.jclee.me/v1
+          OPENAI__KEY: ${{ secrets.MINIMAX_API_KEY }}
+          OPENAI__API_BASE: https://api.minimax.io/v1
+          OPENAI_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          OPENAI_BASE_URL: https://api.minimax.io/v1
           LITELLM_LOCAL_MODEL_COST_MAP: "True"
-          CONFIG__MODEL: gpt-5.5
-          CONFIG__FALLBACK_MODELS: '["minimax-m2.7", "gpt-5.5"]'
+          CONFIG__MODEL: MiniMax-M3
+          CONFIG__FALLBACK_MODELS: '["MiniMax-M3"]'
           CONFIG__RESPONSE_LANGUAGE: ko
           CONFIG__AI_TIMEOUT: '300'
-          CONFIG__CUSTOM_MODEL_MAX_TOKENS: "128000"
+          CONFIG__CUSTOM_MODEL_MAX_TOKENS: "1000000"
           GITHUB__USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_REVIEWER__REQUIRE_SECURITY_REVIEW: 'true'
           PR_REVIEWER__REQUIRE_TESTS_REVIEW: 'false'


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- PR 리뷰 및 보안 리뷰 MiniMax API 마이그레이션

- README 자동 생성 워크플로우 MiniMax 직접 연동

- 모델을 MiniMax-M3 단일 모델로 통합

- Rate limit 방지를 위한 max-parallel 설정 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Review / Security Review"] --> B["MiniMax Direct API"]
  C["README Generator"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>10_pr-review.yml</strong><dd><code>PR 리뷰 워크플로우 MiniMax 직접 API 마이그레이션</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/10_pr-review.yml

<ul><li>모델 행렬을 <code>MiniMax-M3</code> 단일 모델로 변경하고 <code>max-parallel: 1</code> 추가<br> <li> API 엔드포인트를 <code>api.minimax.io</code>로 전환, 인증키를 <code>MINIMAX_API_KEY</code>로 변경<br> <li> fallback 모델을 <code>MiniMax-M3</code> 단일 모델로 단순화<br> <li> <code>CUSTOM_MODEL_MAX_TOKENS</code>를 1,000,000으로 확대</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/189/files#diff-e0248294e18c71b65ec8bd370fad557a9d6126473c7baca6a3df2dd574136be1">+24/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>20_readme-gen.yml</strong><dd><code>README 생성 워크플로우 MiniMax API 전환</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/20_readme-gen.yml

<ul><li><code>CLIPROXY_API_KEY</code>를 <code>MINIMAX_API_KEY</code>로 변경<br> <li> <code>OPENAI_BASE_URL</code>을 <code>https://api.minimax.io/v1</code>로 수정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/189/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>11_pr-review.yml</strong><dd><code>보안 리뷰 워크플로우 MiniMax 직접 연동</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/security/11_pr-review.yml

<ul><li><code>gpt-5.5</code> 모델을 <code>MiniMax-M3</code>로 교체<br> <li> fallback 모델 목록을 <code>MiniMax-M3</code> 단일 모델로 단순화<br> <li> API 키 및 엔드포인트를 MiniMax 직접 API로 변경<br> <li> <code>CUSTOM_MODEL_MAX_TOKENS</code>를 1,000,000으로 증가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/189/files#diff-c75b1989a2e6809b6adb46fb2e03c008d1bd16935fdbb66ced9891b356a31bb1">+15/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

