### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/19_issue-backfill.yml
+++ b/.github/workflows/19_issue-backfill.yml
@@ -17,6 +17,11 @@ name: Issue Backfill
 # actually mutates labels.
 
 on:
+  issues:
+    types: [opened, edited, reopened, labeled, unlabeled]
+  workflow_run:
+    workflows: ["Issue Management", "Issue Classification"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -48,6 +53,7 @@ concurrency:
 
 jobs:
   backfill:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -5,6 +5,11 @@ name: Downstream Health Check
 # Closes the issue when all repos are green.
 
 on:
+  workflow_run:
+    workflows: ["Auto Deploy Workflows", "PR Checks", "Gitleaks", "actionlint"]
+    types: [completed]
+  repository_dispatch:
+    types: [downstream-health-check]
   workflow_dispatch:
 
 permissions:
@@ -17,6 +22,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check downstream workflow health

--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -23,36 +23,20 @@ on:
       - "Drift Detector"
       - "CI Auto-Heal"
       - "Repository Health Check"
+      - "Auto Hardcode Scan"
+      - "Live E2E Tests"
     types: [completed]
+  issues:
+    types: [opened, edited, reopened, closed, labeled, unlabeled]
+  repository_dispatch:
+    types: [ci-failure-sweep]
   workflow_dispatch:
     inputs:
-      workflow_name:
-        description: Workflow name
-        required: true
-        type: string
-      head_sha:
-        description: Commit SHA
-        required: true
-        type: string
-      run_id:
-        description: Run ID (0 for synthetic)
-        required: true
-        type: string
-      conclusion:
-        description: Conclusion (failure or success)
-        required: true
-        type: string
-        default: failure
       dry_run:
         description: Skip actual issue ops
         required: false
         type: boolean
         default: false
-      pr_number:
-        description: PR number (0 if not applicable)
-        required: false
-        type: string
-        default: '0'
 
 permissions:
   contents: read
@@ -60,14 +44,14 @@ permissions:
   actions: read
 
 concurrency:
-  group: ci-failure-issues-${{ github.event.workflow_run.head_sha || inputs.head_sha || github.run_id }}
+  group: ci-failure-issues-${{ github.event.workflow_run.head_sha || github.run_id }}
   cancel-in-progress: false
 
 jobs:
   triage:
     # The event-driven path handles workflow_run + manual dispatch. The daily
     # schedule is handled by the separate `sweep` job below.
-    if: github.event_name != 'schedule'
+    if: github.event_name == 'workflow_run'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     # Trigger only on FAILURE conclusion (success → close stale below).
@@ -81,11 +65,11 @@ jobs:
         id: ev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_WORKFLOW_NAME: ${{ inputs.workflow_name }}
-          INPUT_HEAD_SHA: ${{ inputs.head_sha }}
-          INPUT_RUN_ID: ${{ inputs.run_id }}
-          INPUT_CONCLUSION: ${{ inputs.conclusion }}
-          INPUT_PR_NUMBER: ${{ inputs.pr_number || '0' }}
+          INPUT_WORKFLOW_NAME: ''
+          INPUT_HEAD_SHA: ''
+          INPUT_RUN_ID: ''
+          INPUT_CONCLUSION: ''
+          INPUT_PR_NUMBER: '0'
           EVENT_NAME: ${{ github.event_name }}
           WF_RUN_NAME: ${{ github.event.workflow_run.name }}
           WF_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -338,7 +322,7 @@ jobs:
   # This is the safety-net layer for issues the event-driven path missed
   # (missed webhooks, renamed workflows, legacy per-run-id-titled issues).
   sweep:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'issues' || github.event_name == 'repository_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/60_ci-auto-heal.yml
+++ b/.github/workflows/60_ci-auto-heal.yml
@@ -1,5 +1,12 @@
 name: CI Auto-Heal
 on:
+  workflow_run:
+    workflows: ["Sanity", "PR Checks", "Gitleaks", "CodeQL", "actionlint", "E2E Tests", "Downstream Health Check"]
+    types: [completed]
+  check_suite:
+    types: [completed]
+  repository_dispatch:
+    types: [ci-auto-heal]
   workflow_dispatch:
 permissions:
   contents: write
@@ -10,6 +17,7 @@ concurrency:
   cancel-in-progress: false
 jobs:
   heal:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 30
     name: Cross-repo CI auto-heal


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 여러 워크플로우에 자동 트리거와 실행 조건 추가

- CI 실패 이슈 워크플로우의 수동 입력 제거

- `workflow_run` 결과에 따른 분기 조건 설정

- 이슈/디스패치 이벤트로 자동화 범위 확대


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["외부 이벤트 발생"] --> B["트리거 조건 평가"]
  B -- "조건 충족" --> C["워크플로우 실행"]
  B -- "조건 불충족" --> D["실행 스킵"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>19_issue-backfill.yml</strong><dd><code>이슈 백필 워크플로우 이벤트 트리거 및 조건 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/19_issue-backfill.yml

<ul><li><code>issues</code> 이벤트 및 <code>workflow_run</code> 트리거 추가<br> <li> <code>workflow_run</code> 성공 시에만 실행하는 <code>if</code> 조건 추가<br> <li> 기존 <code>workflow_dispatch</code> 수동 실행 옵션 유지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/198/files#diff-914e840b0cc93b17a66743ce19039a60377cd51fd51d85800fdb6edf4072393d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>다운스트림 헬스 체크 자동 트리거 및 조건 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li><code>workflow_run</code> 및 <code>repository_dispatch</code> 트리거 추가<br> <li> <code>workflow_run</code> 성공 시에만 실행하는 <code>if</code> 조건 추가<br> <li> 기존 <code>workflow_dispatch</code> 수동 실행 옵션 유지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/198/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>CI 실패 이슈 워크플로우 이벤트 기반 자동화 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li><code>workflow_run</code> 모니터링 대상에 신규 워크플로우 2개 추가<br> <li> <code>issues</code>, <code>repository_dispatch</code> 트리거 및 <code>sweep</code> 조건 확대<br> <li> 수동 입력 파라미터 제거하고 <code>dry_run</code>만 남김<br> <li> <code>triage</code> 잡을 <code>workflow_run</code> 전용으로 제한</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/198/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+14/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>60_ci-auto-heal.yml</strong><dd><code>CI 자동 복구 워크플로우 이벤트 트리거 및 조건 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/60_ci-auto-heal.yml

<ul><li><code>workflow_run</code>, <code>check_suite</code>, <code>repository_dispatch</code> 트리거 추가<br> <li> <code>workflow_run</code> 실패 시에만 실행하는 <code>if</code> 조건 추가<br> <li> 기존 <code>workflow_dispatch</code> 수동 실행 옵션 유지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/198/files#diff-9dcf0b5c34b1734903099272c2aa06e279f03d19efb5bf508c4121cadb00ed00">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

