### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/19_issue-backfill.yml
+++ b/.github/workflows/19_issue-backfill.yml
@@ -17,10 +17,11 @@ name: Issue Backfill
 # actually mutates labels.
 
 on:
-  issues:
-    types: [opened, edited, reopened, labeled, unlabeled]
+  # NOTE: not triggered by `issues:` nor by Issue Management/Classification —
+  # 19 ADDS the in-progress label, which would re-fire those issue workflows
+  # and loop. Driven by a master-activity pulse (Sanity) + manual dispatch.
   workflow_run:
-    workflows: ["Issue Management", "Issue Classification"]
+    workflows: ["Sanity"]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -70,7 +71,10 @@ jobs:
           # the backfill silently completes without triggering branch
           # creation.
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ inputs.dry_run == false && 'false' || 'true' }}
+          # Mutate ONLY on an explicit manual dispatch with dry_run=false.
+          # Any event-driven (workflow_run) run is always dry-run so it can
+          # never add labels (which would re-trigger issue workflows / loop).
+          DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) && 'false' || 'true' }}
           MIN_AGE_DAYS: ${{ inputs.min_age_days || '5' }}
           MAX_PICKS: ${{ inputs.max_picks || '3' }}
           LABEL: ${{ inputs.label || 'in-progress' }}
@@ -81,9 +85,14 @@ jobs:
           THRESHOLD=$((NOW - MIN_AGE_DAYS * 86400))
           SKIP_LABELS="wontfix duplicate invalid bot-review ci-failure automated dependencies"
           # Pre-fetch open issues; up to 100 per page is fine for our repos.
-          gh issue list --repo "$REPO" --state open --limit 100 \
+          # Tolerate transient API failures (rate limit, 5xx): warn and skip this
+          # run rather than failing the workflow (event-driven runs are frequent).
+          if ! gh issue list --repo "$REPO" --state open --limit 100 \
             --json number,title,updatedAt,labels,assignees \
-            > /tmp/issues.json
+            > /tmp/issues.json 2>/tmp/issues.err; then
+            echo "::warning::issue-backfill: gh issue list failed for $REPO (likely transient/rate-limit); skipping this run. $(cat /tmp/issues.err)"
+            exit 0
+          fi
           PICKED=0
           {
             echo "## Issue Backfill Candidates ($REPO)"

--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -50,8 +50,8 @@ concurrency:
 
 jobs:
   triage:
-    # The event-driven path handles workflow_run + manual dispatch. The daily
-    # schedule is handled by the separate `sweep` job below.
+    # Event-driven triage: fires only on workflow_run of a watched workflow.
+    # The stale-issue sweep (manual/repository_dispatch/recovery) is the `sweep` job below.
     if: github.event_name == 'workflow_run'
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
@@ -66,11 +66,6 @@ jobs:
         id: ev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_WORKFLOW_NAME: ''
-          INPUT_HEAD_SHA: ''
-          INPUT_RUN_ID: ''
-          INPUT_CONCLUSION: ''
-          INPUT_PR_NUMBER: '0'
           EVENT_NAME: ${{ github.event_name }}
           WF_RUN_NAME: ${{ github.event.workflow_run.name }}
           WF_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -79,19 +74,13 @@ jobs:
           WF_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '0' }}
         run: |
           set -eu
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            WF_NAME="$INPUT_WORKFLOW_NAME"
-            HEAD_SHA="$INPUT_HEAD_SHA"
-            RUN_ID="$INPUT_RUN_ID"
-            CONCLUSION="$INPUT_CONCLUSION"
-            PR_NUMBER="$INPUT_PR_NUMBER"
-          else
-            WF_NAME="$WF_RUN_NAME"
-            HEAD_SHA="$WF_RUN_HEAD_SHA"
-            RUN_ID="$WF_RUN_ID"
-            CONCLUSION="$WF_RUN_CONCLUSION"
-            PR_NUMBER="$WF_RUN_PR_NUMBER"
-          fi
+          # triage runs only on workflow_run (job `if:` above), so the event
+          # fields always come from github.event.workflow_run.
+          WF_NAME="$WF_RUN_NAME"
+          HEAD_SHA="$WF_RUN_HEAD_SHA"
+          RUN_ID="$WF_RUN_ID"
+          CONCLUSION="$WF_RUN_CONCLUSION"
+          PR_NUMBER="$WF_RUN_PR_NUMBER"
 
           # Validate inputs
           if ! [[ "$HEAD_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -162,7 +151,7 @@ jobs:
           set -euo pipefail
           # Map the recovered workflow NAME -> title substrings of the stable
           # (and legacy) failure/health issues it creates. On success, close
-          # them immediately (event-driven), complementing the daily sweep.
+          # them immediately (event-driven), complementing the manual/recovery sweep.
           case "$WF_NAME" in
             "Gitleaks") SUBS='Gitleaks Scan Failed' ;;
             "CodeQL") SUBS='CodeQL Analysis Failed' ;;
@@ -316,7 +305,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-on-failure
 
-  # Daily sweep: auto-close stale failure/health issues whose originating
+  # Stale-issue sweep (manual / repository_dispatch / on a watched workflow's
   # workflow has since recovered. Maps each open issue to its workflow file by
   # title pattern, queries that workflow's latest COMPLETED run on the default
   # branch, and closes the issue when the latest run conclusion is success.

--- a/.github/workflows/60_ci-auto-heal.yml
+++ b/.github/workflows/60_ci-auto-heal.yml
@@ -1,7 +1,7 @@
 name: CI Auto-Heal
 on:
   workflow_run:
-    workflows: ["Sanity", "PR Checks", "Gitleaks", "CodeQL", "actionlint", "E2E Tests", "Downstream Health Check"]
+    workflows: ["Sanity", "PR Checks", "Gitleaks", "CodeQL", "actionlint", "E2E Tests", "Downstream Health Check", "Release Publish", "Scorecard supply-chain security"]
     types: [completed]
   check_suite:
     types: [completed]

--- a/.github/workflows/91_issue-classification.yml
+++ b/.github/workflows/91_issue-classification.yml
@@ -10,7 +10,7 @@ name: Issue Classification
 #   * resolved-from-signal      — on edits/comments carrying an explicit
 #                                 "fixed/resolved" signal, label `resolved`
 #                                 (close only when opted in).
-#   * resolved-sweep            — scheduled sweep: open issues whose linked PR is
+#   * resolved-sweep            — manual sweep (workflow_dispatch): open issues whose linked PR is
 #                                 already merged get labeled/closed.
 #
 # All pure logic lives in `.github/scripts/issue-classifier.cjs` (unit-tested via
@@ -78,7 +78,7 @@ env:
   DUPLICATE_CLOSE_THRESHOLD: ${{ inputs.duplicate_close_threshold || '0.86' }}
   CLOSE_DUPLICATES: ${{ inputs.close_duplicates || 'false' }}
   # Default ON. Only a workflow_dispatch run that explicitly sets the input to
-  # false may disable it; on issues/PR/schedule events `inputs` is absent and we
+  # false may disable it; on issues/PR events `inputs` is absent and we
   # must NOT let empty-string coerce to false.
   CLOSE_RESOLVED_BY_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.close_resolved_by_pr == false && 'false' || 'true' }}
   CLOSE_RESOLVED_BY_SIGNAL: ${{ inputs.close_resolved_by_signal || 'false' }}


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Issue Backfill 루프 방지 및 API 복원력 강화

- CI 실패 트라이지 이벤트 로직 단순화

- CI Auto-Heal 대상 워크플로우 확장

- Issue Classification 주석 및 설명 문서 정정


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Sanity["Sanity 워크플로우 완료"] -- "트리거" --> Backfill["Issue Backfill"]
  Backfill -- "dry-run 강제" --> Check{"수동 실행 여부"}
  Check -- "예" --> Label["라벨 추가"]
  Check -- "아니오" --> Skip["실행 스킵"]
  Backfill -- "API 실패" --> Warn["경고 출력"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>19_issue-backfill.yml</strong><dd><code>Issue Backfill 루프 방지 및 API 복원력 강화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/19_issue-backfill.yml

<ul><li><code>issues:</code> 이벤트 트리거와 <code>Issue Management</code>/<code>Issue Classification</code> <code>workflow_run</code> <br>의존성 제거, <code>Sanity</code> 완료 시에만 실행하도록 변경<br> <li> 이벤트 기반 실행 시 <code>DRY_RUN</code>을 항상 <code>true</code>로 강제하여 <code>in-progress</code> 라벨 추가로 인한 다운스트림 워크플로우 <br>무한 루프 방지<br> <li> <code>gh issue list</code> 호출 시 일시적 API 실패(속도 제한, 5xx)에 대해 워크플로우를 실패시키지 않고 경고 출력 후 <br>실행 건너뛰도록 처리</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/207/files#diff-914e840b0cc93b17a66743ce19039a60377cd51fd51d85800fdb6edf4072393d">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>CI 실패 이슈 트라이지 로직 단순화</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li><code>triage</code> 잡이 <code>workflow_run</code> 전용으로 동작하도록 미사용 <code>INPUT_*</code> 환경변수와 <code>workflow_dispatch</code> <br>분기 로직 제거<br> <li> 이벤트 기반 경로와 스위프 잡의 역할을 명확히 구분하도록 주석 개선<br> <li> <code>sweep</code> 잡 주석을 일간 스케줄이 아닌 수동/복구 실행임을 명시하도록 수정</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/207/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+11/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>60_ci-auto-heal.yml</strong><dd><code>CI Auto-Heal 모니터링 대상 확장</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/60_ci-auto-heal.yml

<ul><li><code>workflow_run</code> 트리거 대상 워크플로우 목록에 <code>Release Publish</code>와 <code>Scorecard supply-chain </code><br><code>security</code> 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/207/files#diff-9dcf0b5c34b1734903099272c2aa06e279f03d19efb5bf508c4121cadb00ed00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>91_issue-classification.yml</strong><dd><code>Issue Classification 주석 및 설명 문서 정정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/91_issue-classification.yml

<ul><li><code>resolved-sweep</code>이 <code>schedule</code>이 아닌 <code>workflow_dispatch</code> 기반임을 주석에 정정<br> <li> <code>inputs</code> 부재 시 동작 설명 문구에서 <code>schedule</code> 이벤트 제거</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/207/files#diff-925a942cf5a654079bece14ac3b1117622177ca4276c6bdc6cde64a0f9e34954">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

