### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/10_pr-review.yml
+++ b/.github/workflows/10_pr-review.yml
@@ -52,10 +52,10 @@ jobs:
           path: pr-agent-src
           fetch-depth: 1
 
-      - name: Set up Python
-        run: |
-          python3 --version
-          which python3
+      - name: Set up Python 3.12
+        uses: ./.github/actions/setup-python-compatible
+        with:
+          python-version: '3.12'
 
       - name: Cache pip dependencies
         uses: actions/cache@v5
@@ -68,7 +68,9 @@ jobs:
       - name: Install pr-agent
         working-directory: pr-agent-src
         run: |
-          python3 -m venv .venv
+          # Use the venv that setup-python-compatible put on PATH (self-hosted
+          # Debian lacks python3-venv/ensurepip, so `python3 -m venv` fails).
+          python -m venv .venv || uv venv --seed .venv
           .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install -e .
 

--- a/.github/workflows/14_bot-auto-fix.yml
+++ b/.github/workflows/14_bot-auto-fix.yml
@@ -51,6 +51,12 @@ jobs:
 
       - name: Run naming validator with --fix
         id: fix
+        env:
+          # The self-hosted runner has HOME unset, so `go env` fails with
+          # "GOCACHE is not defined and neither $XDG_CACHE_HOME nor $HOME are
+          # defined". Provide cache dirs explicitly.
+          GOCACHE: ${{ runner.temp }}/go-build
+          GOMODCACHE: ${{ runner.temp }}/go-mod
         run: |
           set -eu
           echo "Running validate-naming --fix..."


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Fixed Python setup in PR review workflow by using custom `setup-python-compatible` action instead of manual `python3` setup

- Added `uv venv --seed .venv` fallback in PR review workflow for self-hosted Debian runners lacking `python3-venv/ensurepip`

- Added `GOCACHE` and `GOMODCACHE` environment variables in bot-auto-fix workflow to handle self-hosted runners with unset `HOME`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[self-hosted runner] --> B[PR review workflow]
  A --> C[Bot auto-fix workflow]
  B --> D[setup-python-compatible action]
  B --> E[uv venv fallback]
  C --> F[GOCACHE + GOMODCACHE env]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>10_pr-review.yml</strong><dd><code>Fix Python venv creation for self-hosted Debian runners</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/10_pr-review.yml

<ul><li>Replaced manual Python 3 setup with custom <code>setup-python-compatible</code> <br>action<br> <li> Changed <code>python3 -m venv</code> to <code>python -m venv</code> with <code>uv venv --seed .venv</code> <br>fallback<br> <li> Updated pip cache key format for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/250/files#diff-e0248294e18c71b65ec8bd370fad557a9d6126473c7baca6a3df2dd574136be1">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>14_bot-auto-fix.yml</strong><dd><code>Add Go cache environment variables for self-hosted runners</code></dd></summary>
<hr>

.github/workflows/14_bot-auto-fix.yml

<ul><li>Added <code>GOCACHE</code> and <code>GOMODCACHE</code> environment variables<br> <li> Resolves Go cache initialization failure on self-hosted runners with <br>unset HOME</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/250/files#diff-e594d8670707ce5ac3fa2b465eed7ddf1c669ba5d731b72d369d7166ffcb7d28">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

