### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -25,13 +25,32 @@ runs:
         nas_base="/mnt/nas-cache"
         local_base="${RUNNER_TEMP:-/tmp}/gha-cache"
 
-        # Prefer the NAS mount; degrade to a local path if it is missing or
-        # not writable so a broken mount never hard-fails the build.
-        if [ -d "$nas_base" ] && [ -w "$nas_base" ]; then
-          base="$nas_base"
+        # Prefer the NAS mount; self-heal its permissions if needed (a freshly
+        # provisioned NFS volume is root-owned, but the runner is non-root).
+        # Degrade to a local path only if the NAS mount is truly unusable, so a
+        # broken mount never hard-fails the build.
+        base="$local_base"
+        if [ -d "$nas_base" ]; then
+          probe="$nas_base/.write-probe.$$"
+          if (mkdir -p "$nas_base/$runner_slug" && touch "$probe") >/dev/null 2>&1; then
+            rm -f "$probe"
+            base="$nas_base"
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+            # Self-heal: claim the cache tree for the runner user once.
+            if sudo mkdir -p "$nas_base" \
+               && sudo chown "$(id -u):$(id -g)" "$nas_base" \
+               && sudo chmod 0775 "$nas_base" \
+               && touch "$probe" >/dev/null 2>&1; then
+              rm -f "$probe"
+              base="$nas_base"
+              echo "build cache: self-healed NAS mount permissions on $nas_base"
+            fi
+          fi
+        fi
+
+        if [ "$base" = "$nas_base" ]; then
           echo "build cache: using NAS mount $nas_base"
         else
-          base="$local_base"
           echo "::warning::NAS mount $nas_base unavailable/unwritable; falling back to $local_base"
         fi
 


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement


___

### **Description**
- Build cache NAS mount handling: added self-healing capability for NFS volumes with incorrect permissions (root-owned)

- Uses probe file check before falling back to local cache directory

- Attempts sudo-based permission correction when runner user lacks write access to mounted NAS

- Falls back to local temp path only when NAS is truly unusable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A{check NAS exists} --> B{write probe file}
  B -->|success| C[Use NAS mount]
  B -->|fail| D{sudo available?}
  D -->|yes| E[Self-heal: chown/chmod NAS]
  E -->|success| C
  E -->|fail| F[Use local temp]
  D -->|no| F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Build cache NAS mount self-healing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/setup-build-cache/action.yml

<ul><li>Added permission self-healing for NAS/NFS cache mounts that may be <br>root-owned<br> <li> Replaced simple writable check with probe file creation test<br> <li> Added sudo-based chown/chmod fallback to claim cache tree for runner <br>user<br> <li> Falls back to local temp directory only when NAS is completely <br>unusable</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/account/pull/268/files#diff-e22dec1852d6dcbcb4a828b3ac0538fa7b31fc4cc637f5828e2111e763fba58c">+24/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

